### PR TITLE
Add tito widget to button

### DIFF
--- a/form.css
+++ b/form.css
@@ -32,4 +32,8 @@
       width: auto;
     }
   }
+  & button {
+      padding: 0;
+      text-transform: uppercase;
+  }
 }

--- a/index.css
+++ b/index.css
@@ -95,3 +95,8 @@ select {
   background: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSI4IiBoZWlnaHQ9IjE2Ij48cGF0aCBmaWxsLXJ1bGU9ImV2ZW5vZGQiIGQ9Ik00IDE2TDAgOWg4TTQgMGw0IDdIMCIvPjwvc3ZnPg==) no-repeat right 10px center;
   padding: 0 10px;
 }
+
+.tito-tickets-button {
+    background: none;
+    border: none;
+}

--- a/index.html
+++ b/index.html
@@ -12,6 +12,9 @@
     <script src="/dist/vendor.js"></script>
     <script src="/dist/main.js"></script>
     <script src="https://js.tito.io/v1" async></script>
+    <script>
+        TitoDevelopmentMode = location.host !== 'wafflejs.com'
+    </script>
   </head>
   <body ng-app="wafflejs" ng-strict-di>
     <header>

--- a/index.html
+++ b/index.html
@@ -11,6 +11,7 @@
     <base href="/" />
     <script src="/dist/vendor.js"></script>
     <script src="/dist/main.js"></script>
+    <script src="https://js.tito.io/v1" async></script>
   </head>
   <body ng-app="wafflejs" ng-strict-di>
     <header>
@@ -34,7 +35,7 @@
     <footer class="fixed">
       <div class="row start-xs end-sm">
         <div class="col-xs-12 col-sm-5 col-md-3">
-          <a class="btn primary xs-full-width" href="https://ti.to/wafflejs/march">
+          <tito-button class="btn primary xs-full-width" event="wafflejs/march">
             <div class="row">
               <div class="col-xs-7 start-xs col-sm-12 center-sm">
                 <!-- Buy Waffle – $10 -->
@@ -48,7 +49,7 @@
                 </small>
               </div>
             </div>
-          </a>
+          </tito-button>
         </div>
       </div>
     </footer>


### PR DESCRIPTION
This change adds the tito integration js on the home page, and updates the `a` tag to be a `tito-button` tag. It also adds css to make the button appear like a regular block element, without the usual browser styling. Let me know if I missed anything, tested and working in chrome in local development mode.

Fixes #29