### PR TITLE
fix header spacing difference between front and tickets page

### DIFF
--- a/routes/index/index.css
+++ b/routes/index/index.css
@@ -20,6 +20,9 @@
     h3 {
       margin-bottom: 3rem;
     }
+    .details {
+      margin-top: 1rem;
+    }
   }
 
   #hero {

--- a/routes/index/index.jade
+++ b/routes/index/index.jade
@@ -10,7 +10,7 @@ div( class=className )
           a.black( ng-repeat='(name, url) in index.day.charity' ng-href='{{url}}' ) {{name}}
           | .
 
-      .col-xs-12.col-sm-5
+      .col-xs-12.col-sm-5.details
         h5 Date & Time
         h3: a.black( href='/models/WaffleJS.ics' target='_self' )
           | {{index.day.date | date:'EEEE, MMMM d':'UTC'}} at 7 PM

--- a/routes/tickets/index.css
+++ b/routes/tickets/index.css
@@ -2,6 +2,15 @@
 @import '../../media.css';
 
 :local(.className) {
+  #header {
+    h1 {
+      margin-bottom: 1.5rem;
+    }
+    .details {
+      margin-top: 1rem;
+    }
+  }
+
   tito-widget {
     h3 {
       margin-top: 2em;

--- a/routes/tickets/index.jade
+++ b/routes/tickets/index.jade
@@ -8,7 +8,7 @@ div( class=className )
           a.black( ng-repeat='(name, url) in tickets.day.charity' ng-href='{{url}}' ) {{name}}
           | .
 
-      .col-xs-12.col-sm-5
+      .col-xs-12.col-sm-5.details
         h5 Date & Time
         h3: a.black( href='/models/WaffleJS.ics' target='_self' )
           | {{tickets.day.date | date:'EEEE, MMMM d':'UTC'}} at 7 PM


### PR DESCRIPTION
On the tickets page, the "DATE & TIME" text is  flush w/ the top border. This is different from the front page, where there's some space above. This causes the text to appear to jump up when navigating to the tickets page.

![image](https://cloud.githubusercontent.com/assets/16893/18156037/d094cc5e-6fc7-11e6-941f-1bf8a4275f73.png)

This PR adds `1rem` of spacing above the label on both pages to make them look consistent. It also adds a missing `h1` style that differed between the two pages.