### PR TITLE
Fix horizontal line glitch on Chrome under header

### DIFF
--- a/index.css
+++ b/index.css
@@ -5,11 +5,11 @@
 @import './typography.css';
 
 body {
-  background-color: var(--orange);
-  padding: 5px 0;
+  border-top: 5px solid var(--orange);
+  border-bottom: 5px solid var(--orange);
 }
 
-header, main {
+body, header, main {
   background-color: var(--tan);
 }
 


### PR DESCRIPTION
@billyroh This fixes the issue we saw on my Chrome with the thin orange line. I noticed it was also happening on my phone w/ Android Chrome.

I think this was caused by subpixel layout: perhaps the `<header>` is sized to rems, and the total height is not rounded up to a full pixel, causing a tiny sliver of the orange page background to show through. Oddly, looking at the computer heights in the inspector didn't reveal a subpixel height, but I can't think of another explanation.

![screenshot from 2016-10-14 00-00-11](https://cloud.githubusercontent.com/assets/16893/19378605/5440113e-91a2-11e6-8893-c9dde0e58e78.png)

