### PR TITLE
Fix deduplication of contributor avatars

### DIFF
--- a/routes/index/index.js
+++ b/routes/index/index.js
@@ -21,7 +21,7 @@ module.exports = angular.module('wafflejs.routes.index', [
           }))
           .flatten().flatten()
           .compact()
-          .uniq(false, 'twitter')
+          .uniqBy('twitter')
           .reject({ exclude: true })
           .forEach((person) => person.size = `${Math.random() * 33 + 30}px`)
           .shuffle()


### PR DESCRIPTION
Noticed some doubled-up avatars on the front page. This should fix the deduplication. You can check it by adding `_.tap(x => console.log(x.length))` before and after the `uniqBy` call and seeing that the number drops :arrow_down:.

