### PR TITLE
June got moved to May

### DIFF
--- a/routes/tickets/index.jade
+++ b/routes/tickets/index.jade
@@ -24,5 +24,6 @@ div( class=className )
       | . Talks are recorded in 360º video and your image may appear
       | in videos posted online. <a href="mailto:hi@wafflejs.com">Contact us</a>
       | if you have any concerns.
-    tito-widget( event='wafflejs/{{tickets.day.date | date:"MMMM":"UTC"}}' )
+    //- tito-widget( event='wafflejs/{{tickets.day.date | date:"MMMM":"UTC"}}' )
+    tito-widget( event='wafflejs/june' )
       h3 Loading…


### PR DESCRIPTION
I know, it's confusing. hardcode the tito link for now. will need to change it back right after the event.