### PR TITLE
revert hardcoding of the june url

### DIFF
--- a/routes/tickets/index.jade
+++ b/routes/tickets/index.jade
@@ -24,6 +24,5 @@ div( class=className )
       | . Talks are recorded in 360º video and your image may appear
       | in videos posted online. <a href="mailto:hi@wafflejs.com">Contact us</a>
       | if you have any concerns.
-    //- tito-widget( event='wafflejs/{{tickets.day.date | date:"MMMM":"UTC"}}' )
-    tito-widget( event='wafflejs/june' )
+    tito-widget( event='wafflejs/{{tickets.day.date | date:"MMMM":"UTC"}}' )
       h3 Loading…


### PR DESCRIPTION
For May Pt. 2, we had to hardcode the June URL. This reverts that.