### PR TITLE
Change Hustle link to blog page

### DIFF
--- a/models/calendar.yml
+++ b/models/calendar.yml
@@ -268,7 +268,7 @@
     
   sponsors: 
       - Opendoor: https://www.opendoor.com/jobs
-      - Hustle: https://www.hustle.com/careers
+      - Hustle: https://blog.hustle.com/
       - Bugsnag: https://www.bugsnag.com/jobs
       
 - day: '2018-12-05'


### PR DESCRIPTION
In startup world things change quickly. We are unfortunately no longer hiring at the moment. We still want for folks to hear about and get to know Hustle though, so we want to change this link to point to our blog page.
