### PR TITLE
adjust mobile button

### DIFF
--- a/form.css
+++ b/form.css
@@ -43,8 +43,5 @@ button, .btn {
   &.xs-full-width {
     width: 100%;
     padding: .75rem 1rem;
-    @media (--sm-viewport) {
-      width: auto;
-    }
   }
 }

--- a/index.css
+++ b/index.css
@@ -64,11 +64,7 @@ footer {
   font-size: x-large;
 
   @media (--xs-viewport-only) {
-    background-color: var(--orange);
-    .btn {
-      border-radius: 0;
-      box-shadow: none;
-    }
+    margin: 1.75rem 1rem;
   }
 
   @media (--sm-viewport) {

--- a/index.css
+++ b/index.css
@@ -64,7 +64,7 @@ footer {
   font-size: x-large;
 
   @media (--xs-viewport-only) {
-    margin: 1.75rem 1rem;
+    margin: calc(1rem + env(safe-area-inset-bottom)) 1rem;
   }
 
   @media (--sm-viewport) {

--- a/index.css
+++ b/index.css
@@ -64,7 +64,8 @@ footer {
   font-size: x-large;
 
   @media (--xs-viewport-only) {
-    margin: calc(1rem + env(safe-area-inset-bottom)) 1rem;
+    margin: 1rem;
+    margin-bottom: calc(1rem + env(safe-area-inset-bottom));
   }
 
   @media (--sm-viewport) {

--- a/index.jade
+++ b/index.jade
@@ -36,15 +36,13 @@ html
       .row.start-xs.end-sm
         .col-xs-12.col-sm-5.col-md-3
           a.btn.primary.xs-full-width( ui-sref='tickets' ui-sref-active='ng-hide' )
-            .row
-              .col-xs-7.start-xs.col-sm-12.center-sm
-                // Buy Waffle – $10
-                | Buy Doughnut – $10
-                // Sold Out 😅
-              .col-xs-5.end-xs.col-sm-12.center-sm
-                small
-                  | Ticket Included
-                  // Join Waiting List
+            div
+              // Buy Waffle – $10
+              | Buy Doughnut – $10
+              // Sold Out 😅
+            small
+              | Ticket Included
+              // Join Waiting List
 
     //-- Twitter universal website tag code
     script.


### PR DESCRIPTION
This adjusts the styling of the mobile button such that it's easier to tap. It also uses the `env(safe-area-inset-bottom)` variable to provide enough margin to avoid the home button indicator on iPhone X.

[Read more about the `env()` variable here](https://webkit.org/blog/7929/designing-websites-for-iphone-x/)

View | Before | After
--- | --- | ---
Mobile | <img width="408" alt="screen shot 2019-02-13 at 13 52 43" src="https://user-images.githubusercontent.com/748504/52746619-cb110180-2f96-11e9-8c39-11f0f0bc1053.png">|<img width="391" alt="screen shot 2019-02-13 at 13 58 48" src="https://user-images.githubusercontent.com/748504/52746929-820d7d00-2f97-11e9-8d4c-255ff407a093.png">
Desktop (no change) | <img width="1238" alt="screen shot 2019-02-13 at 13 53 32" src="https://user-images.githubusercontent.com/748504/52746628-ce0bf200-2f96-11e9-9074-f0590665b749.png">|<img width="1243" alt="screen shot 2019-02-13 at 13 53 24" src="https://user-images.githubusercontent.com/748504/52746631-cf3d1f00-2f96-11e9-970b-4a32200f0608.png">
