### PR TITLE
Fix static file + social.png build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: circleci/node:6
+      - image: circleci/node:6-browsers
     steps:
       - checkout
       - restore_cache:

--- a/node_loaders/generate-social-img-loader.js
+++ b/node_loaders/generate-social-img-loader.js
@@ -3,6 +3,7 @@ const fs = require('fs')
 const path = require('path')
 const yaml = require('js-yaml')
 const moment = require('moment')
+const puppeteer = require('puppeteer')
 const generateImage = require('typesetters-son')
 
 module.exports = function() {
@@ -23,15 +24,20 @@ module.exports = function() {
   const dayDate = moment(moment(nextEvent.day))
   const dateText = dayDate.format('dddd, MMMM D')
   const outputName = `social-${dayDate.format('YYYY-MM')}.jpg`
-  generateImage({
-    url: `file:${templatePath}`,
-    output: path.join(__dirname, '../images/', outputName),
-    width: 1200,
-    height: 630,
-    subs: {
-      '#date': `${dateText} at 7 PM`,
-    },
-  })
+
+  puppeteer.launch({args: ['--no-sandbox', '--disable-setuid-sandbox']})
+    .then(browser =>
+      generateImage({
+        browserWSEndpoint: browser.wsEndpoint(),
+        url: `file:${templatePath}`,
+        output: path.join(__dirname, '../images/', outputName),
+        width: 1200,
+        height: 630,
+        subs: {
+          '#date': `${dateText} at 7 PM`,
+        },
+      })
+    )
     .then(
       () => callback(null, `module.exports = '${outputName}'`),
       err => callback(err)

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "postcss-import": "8.2.0",
     "postcss-loader": "0.13.0",
     "postcss-nested": "1.0.1",
+    "puppeteer": "1.13.0",
     "style-loader": "0.21.0",
     "svgo": "0.7.2",
     "svgo-loader": "1.2.1",


### PR DESCRIPTION
It's unclear to me why this changed. Potentially, something changed in CircleCI's execution environment. It's now necessary to run puppeteer with `--no-sandbox --disable-setuid-sandbox` arguments. It's also necessary to use the "circleci/node:6-browsers" docker image, which contains supporting libraries for headless chrome.