### PR TITLE
Accessibility review

### DIFF
--- a/index.jade
+++ b/index.jade
@@ -1,9 +1,9 @@
 doctype html
-html
+html(lang='en')
   head
     title WaffleJS 
     meta( charset='utf-8' )
-    meta( name='viewport' content='initial-scale=1,user-scalable=no' )
+    meta( name='viewport' content='initial-scale=1' )
     meta( property='og:title' content='WaffleJS' )
     meta( property='og:description' content='A fun night of tech, waffles, and karaoke.' )
     meta( property='og:type' content='website' )
@@ -17,11 +17,11 @@ html
           .col-xs-12.col-sm-6.col-md-7
             h4.highlight
               a( ui-sref='index({ day: null })' ) WaffleJS
-              a( href='https://twitter.com/wafflejs' )
+              a( href='https://twitter.com/wafflejs' title='WaffleJS on Twitter' )
                 include images/icons/twitter.svg
-              a( href='https://github.com/wafflejs/wafflejs.github.io/issues' )
+              a( href='https://github.com/wafflejs/wafflejs.github.io/issues' title='WaffleJS on GitHub' )
                 include images/icons/github.svg
-              a( href='https://borojs.slack.com/join/shared_invite/enQtMzM2Nzc5ODExNjY2LTUyNTg3OGMzMzhhNWU2OWViNWUxNmMyZjA5NmMzNGFhYmJkOWE5NzA4NWI5ZGY2NjdmNzBmYWJjMjYzZjkwOGE' )
+              a( href='https://borojs.slack.com/join/shared_invite/enQtMzM2Nzc5ODExNjY2LTUyNTg3OGMzMzhhNWU2OWViNWUxNmMyZjA5NmMzNGFhYmJkOWE5NzA4NWI5ZGY2NjdmNzBmYWJjMjYzZjkwOGE' title='Slack channel' )
                 include images/icons/slack.svg
           .col-xs-12.col-sm-6.end-sm.col-md-5.start-md
             ul.nav

--- a/routes/index/index.jade
+++ b/routes/index/index.jade
@@ -22,7 +22,7 @@ div( class=className )
   
   section#hero: .container-fluid
 
-  section#about: .container-fluid: .row
+  section: .container-fluid: .row
     .col-xs-12.col-sm-6
       :marked
         About
@@ -76,6 +76,7 @@ div( class=className )
           h2 Schedule 
         .col-xs-6
           select(
+	    aria-label='Select event'
             ng-options='month.day|date:"MMMM d" group by month.date.getFullYear() for month in index.calendar'
             ng-model='index.day'
           )
@@ -155,7 +156,7 @@ div( class=className )
     .col-xs-12.col-sm-6: .row.around-xs.middle-xs
       span( class='sponsor' ng-repeat='sponsor in index.day.sponsors' )
         a( href='{{url}}' ng-repeat='(name, url) in sponsor' )
-          img( ng-src='/images/sponsors/{{name}}.svg' )
+          img( ng-src='/images/sponsors/{{name}}.svg' title='{{name}}' )
 
   section#transparency: .container-fluid
     h2 Transparency


### PR DESCRIPTION
WaffleJS is a wonderfully accessible event - this makes the website accessible too. Fixes are:

- [x] Drop maximum-scale rule so people can pinch to read text ([a11project](https://a11yproject.com/posts/never-use-maximum-scale/))
- [x] Add lang='end' so that screenreaders can reliably pronounce text ([w3](https://www.w3.org/TR/UNDERSTANDING-WCAG20/meaning-doc-lang-id.html))
- [x] Add image titles & link titles for screenreaders
- [x] Remove duplicated 'about' ID
- [x] ~~Increase color contrast to WCAG levels~~

The only thing that is visible about these changes is the color contrast view, and there are [a variety of opinions about WCAG standards](https://macwright.org/2019/03/30/color-contrast-is-a-problem.html). You'll also find that OTS accessibility tools will have a little trouble deciding whether things on wafflejs.com are high-contrast because it uses a background image (they are high enough contrast). So that one you can take or leave depending on whether you think that the WCAG guidelines are legit and/or worth the visual difference.