### PR TITLE
Change speaker CFP link for GitHub issues to filter to "cfp" label

### DIFF
--- a/routes/speakers/index.md
+++ b/routes/speakers/index.md
@@ -12,7 +12,7 @@ You can either comment on the current Call for Speakers [issue on Github][1] or
 [send us an email][2]. Come chat with us on [Slack][3] (on the #wafflejs
 channel) if you want immediate feedback.
 
-[1]: https://github.com/wafflejs/wafflejs.github.io/issues
+[1]: https://github.com/wafflejs/wafflejs.github.io/issues?q=is%3Aopen+is%3Aissue+label%3Acfp
 [2]: mailto:speakers@wafflejs.com
 [3]: https://borojs.slack.com/join/shared_invite/enQtMzM2Nzc5ODExNjY2LTUyNTg3OGMzMzhhNWU2OWViNWUxNmMyZjA5NmMzNGFhYmJkOWE5NzA4NWI5ZGY2NjdmNzBmYWJjMjYzZjkwOGE
 


### PR DESCRIPTION
https://github.com/wafflejs/wafflejs.github.io/pull/537 round 2