### PR TITLE
Add Description + Info to Jay's January 2020 Talk

### DIFF
--- a/models/calendar.yml
+++ b/models/calendar.yml
@@ -154,15 +154,18 @@
           pronouns: it
           
     - 8:45 PM:
-        type: Variable Fonts
+        type: Talk
         emoji: 🖋️
-        title: TBD
+        title: Variable Fonts
         description: |
-          TBD
+          Variable fonts allow designers and developers to dynamically change various parameters 
+          of a typeface, going beyond commonly adjusted attributes like font-size and font-weight 
+          to attributes like y-ascender height and optical size. This can be a powerful tool 
+          and also lead to some fun use cases.
         person:
           name: Jay Mahabal
           twitter: jaymahabal
-          pronouns: # examples: she/her, they/them, he/him  (bit.ly/pronoun-faq)
+          pronouns: he/him
           
     - 9:00 PM: Speaker TBA
 


### PR DESCRIPTION
I added a description + some other info to my talk for the January 2020 WaffleJS. Here's a screenshot of what the changes look like:

<img width="598" alt="Screen Shot 2020-01-01 at 10 08 27 PM" src="https://user-images.githubusercontent.com/4358471/71653894-a2dfdd80-2ce3-11ea-8c4e-e475f728d535.png">

Please let me know if you have any suggestions :) 