### PR TITLE
Fix a few minor typos in talk description

### DIFF
--- a/models/calendar.yml
+++ b/models/calendar.yml
@@ -88,9 +88,9 @@
         emoji: 🛡️
         title: How a Statute Helped Shape the Internet, for Both Good and Bad
         description: |
-          Section 230 was a part of a the Communications Decency Act of 1996. While the act
+          Section 230 was a part of the Communications Decency Act of 1996. While the act
           itself was meant to restrict free speech, Section 230 has allowed internet companies to
-          operate as distributers of information, like bookstores, instead of traditional publishers,
+          operate as distributors of information, like bookstores, instead of traditional publishers,
           such as newspapers. The consequences of this freedom has been both
           good and bad. I'm going to talk about the challenges of keeping people safe while
           companies have started to moderate abuse, hate speech, and disinformation.


### PR DESCRIPTION
This is just copy-editing because I noticed a few things awry:

- An additional `a`
- Distributers → Distributors