### PR TITLE
Remove twitter avatars widget

### DIFF
--- a/routes/index/index.jade
+++ b/routes/index/index.jade
@@ -42,15 +42,6 @@ div( class=className )
 
         [1]: http://jsconf.com/codeofconduct.html
         [2]: http://johnnydoughnuts.com
-        
-    .col-xs-12.col-sm-6.people
-      a( href='https://twitter.com/{{person.twitter}}'
-         ng-show='person.twitter'
-         ng-repeat='person in index.people | limitTo:28' )
-        img(
-          title='{{person.name}}'
-          ng-style='{width: person.size, height: person.size }'
-          ng-src='https://avatars.io/twitter/{{person.twitter}}' )
 
   section#get-involved( ng-class='{ tba: index.tba }' ): .container-fluid
     h2 Get Involved


### PR DESCRIPTION
avatars.io seems to be down pretty often these days 😢

<img width="684" alt="Screen Shot 2020-05-09 at 3 17 13 PM" src="https://user-images.githubusercontent.com/455632/81486681-48173f00-920b-11ea-9a72-a134b84143e3.png">
